### PR TITLE
wrong execution path for index.js - fixed

### DIFF
--- a/cli
+++ b/cli
@@ -19,7 +19,7 @@ function start() {
     }
 
     pm2.start({
-      script: 'index.js',
+      script: path.join(__dirname,'index.js'),
       name: 'xcarve'
     }, (err, apps) => {
       pm2.disconnect();


### PR DESCRIPTION
I received errors like this while I tried to run the xcarve-proxy on 
- macOS 10.12.1
- node.js 7.0.0: 

```
/Users/user/index.js
/Users/user/.nvm/versions/node/v7.0.0/lib/node_modules/xcarve-proxy/cli:28
      if (err) throw err
               ^

Error: script not found : /Users/user/index.js
    at Object.Common.resolveAppAttributes (/Users/user/.nvm/versions/node/v7.0.0/lib/node_modules/xcarve-proxy/node_modules/pm2/lib/Common.js:490:11)
[...]
```
With this fix the pm2.start function resolves the right path for the index.js.